### PR TITLE
CounterPick filter + integration with original filters

### DIFF
--- a/public/counter-pick.json
+++ b/public/counter-pick.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "aa_heavy",
+    "title": "AA-heavy",
+    "description": "Blind them, or make sure you can compensate their damage (they don't have burst). Then punish them.",
+    "features": [
+      "blind",
+      "sustain_heal",
+      "long_fights",
+      "stun",
+      "escape"
+    ]
+  },
+  {
+    "id": "cc_heavy",
+    "title": "CC-heavy",
+    "description": "Prevent stuns or shield a victim. Or even better - over-CC them!",
+    "features": [
+      "cleanse",
+      "burst_heal",
+      "shield",
+      "cc",
+      "silence"
+    ]
+  },
+  {
+    "id": "shields",
+    "title": "Shields-heavy",
+    "description": "Just melt their shield or they HP by %",
+    "features": [
+      "anti_shield",
+      "percentage_dmg",
+      "slow",
+      "cc",
+      "silence",
+      "anti_heal"
+    ]
+  },
+  {
+    "id": "hp_heavy",
+    "title": "Fat-hp heroes",
+    "description": "Make them slow and drain HP",
+    "features": [
+      "percentage_dmg",
+      "slow",
+      "cc",
+      "burst",
+      "mage"
+    ]
+  },
+  {
+    "id": "dive",
+    "title": "Dive-combo",
+    "description": "You need to survive their dive, then punish",
+    "features": [
+      "cleanse",
+      "stun",
+      "cc",
+      "shield",
+      "silence",
+      "escape",
+      "burst_heal",
+      "tank",
+      "slow"
+    ]
+  },
+  {
+    "id": "pusher",
+    "title": "Strong pushers",
+    "description": "Outpush him, make him busy (camps) or gank their pusher",
+    "features": [
+      "pushing",
+      "camping",
+      "waveclear",
+      "global",
+      "stealth",
+      "cc",
+      "stun"
+    ]
+  },
+  {
+    "id": "double_supp",
+    "title": "Double Support",
+    "description": "CC them, prevent their healing, or melt their healers mana",
+    "features": [
+      "cc",
+      "silence",
+      "finisher",
+      "initiation",
+      "long_fights",
+      "stealth",
+      "burst"
+    ]
+  }
+]

--- a/public/counter-pick.json
+++ b/public/counter-pick.json
@@ -3,93 +3,93 @@
     "id": "aa_heavy",
     "title": "AA-heavy",
     "description": "Blind them, or make sure you can compensate their damage (they don't have burst). Then punish them.",
-    "features": [
-      "blind",
-      "sustain_heal",
-      "long_fights",
-      "stun",
-      "escape"
-    ]
+    "features": {
+      "blind": true,
+      "sustain_heal": true,
+      "long_fights": true,
+      "stun": true,
+      "escape": true
+    }
   },
   {
     "id": "cc_heavy",
     "title": "CC-heavy",
     "description": "Prevent stuns or shield a victim. Or even better - over-CC them!",
-    "features": [
-      "cleanse",
-      "burst_heal",
-      "shield",
-      "cc",
-      "silence"
-    ]
+    "features": {
+      "cleanse": true,
+      "burst_heal": true,
+      "shield": true,
+      "cc": true,
+      "silence": true
+    }
   },
   {
     "id": "shields",
     "title": "Shields-heavy",
     "description": "Just melt their shield or they HP by %",
-    "features": [
-      "anti_shield",
-      "percentage_dmg",
-      "slow",
-      "cc",
-      "silence",
-      "anti_heal"
-    ]
+    "features": {
+      "anti_shield": true,
+      "percentage_dmg": true,
+      "slow": true,
+      "cc": true,
+      "silence": true,
+      "anti_heal": true
+    }
   },
   {
     "id": "hp_heavy",
     "title": "Fat-hp heroes",
     "description": "Make them slow and drain HP",
-    "features": [
-      "percentage_dmg",
-      "slow",
-      "cc",
-      "burst",
-      "mage"
-    ]
+    "features": {
+      "percentage_dmg": true,
+      "slow": true,
+      "cc": true,
+      "burst": true,
+      "mage": true
+    }
   },
   {
     "id": "dive",
     "title": "Dive-combo",
     "description": "You need to survive their dive, then punish",
-    "features": [
-      "cleanse",
-      "stun",
-      "cc",
-      "shield",
-      "silence",
-      "escape",
-      "burst_heal",
-      "tank",
-      "slow"
-    ]
+    "features": {
+      "cleanse": true,
+      "stun": true,
+      "cc": true,
+      "shield": true,
+      "silence": true,
+      "escape": true,
+      "burst_heal": true,
+      "tank": true,
+      "slow": true
+    }
   },
   {
     "id": "pusher",
     "title": "Strong pushers",
     "description": "Outpush him, make him busy (camps) or gank their pusher",
-    "features": [
-      "pushing",
-      "camping",
-      "waveclear",
-      "global",
-      "stealth",
-      "cc",
-      "stun"
-    ]
+    "features": {
+      "pushing": true,
+      "camping": true,
+      "waveclear": true,
+      "global": true,
+      "stealth": true,
+      "cc": true,
+      "stun": true
+    }
   },
   {
     "id": "double_supp",
     "title": "Double Support",
     "description": "CC them, prevent their healing, or melt their healers mana",
-    "features": [
-      "cc",
-      "silence",
-      "finisher",
-      "initiation",
-      "long_fights",
-      "stealth",
-      "burst"
-    ]
+    "features": {
+      "cc": true,
+      "silence": true,
+      "finisher": true,
+      "initiation": true,
+      "long_fights": true,
+      "stealth": true,
+      "burst": true
+    }
   }
 ]

--- a/public/features.json
+++ b/public/features.json
@@ -126,6 +126,7 @@
     "id": "anti_heal"
   },
   {
-    "id": "percentage_dmg"
+    "id": "percentage_dmg",
+    "title": "% Damage"
   }
 ]

--- a/public/features.json
+++ b/public/features.json
@@ -16,6 +16,10 @@
     "title": "Main tank"
   },
   {
+    "id": "offtank",
+    "title": "Off tank"
+  },
+  {
     "id": "bruiser"
   },
   {
@@ -30,6 +34,18 @@
   },
   {
     "id": "healer"
+  },
+  {
+    "id": "burst_heal",
+    "title": "Burst heal"
+  },
+  {
+    "id": "sustain_heal",
+    "title": "Sustain heal"
+  },
+  {
+    "id": "long_fights",
+    "title": "Long fights (mana independency)"
   },
   {
     "id": "slow"
@@ -96,5 +112,20 @@
   },
   {
     "id": "stealth"
+  },
+  {
+    "id": "cleanse"
+  },
+  {
+    "id": "shield"
+  },
+  {
+    "id": "anti_shield"
+  },
+  {
+    "id": "anti_heal"
+  },
+  {
+    "id": "percentage_dmg"
   }
 ]

--- a/public/features.json
+++ b/public/features.json
@@ -16,10 +16,6 @@
     "title": "Main tank"
   },
   {
-    "id": "offtank",
-    "title": "Off tank"
-  },
-  {
     "id": "bruiser"
   },
   {

--- a/public/heroes.json
+++ b/public/heroes.json
@@ -61,8 +61,7 @@
       "cc": true,
       "summons": true,
       "escape": true,
-      "stun": true,
-      "offtank": true
+      "stun": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/anubarak/bust.jpg"
@@ -77,8 +76,7 @@
       "dd": true,
       "initiaton": true,
       "blind": true,
-      "solo": true,
-      "offtank": true
+      "solo": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/artanis/bust.jpg"
@@ -226,8 +224,7 @@
     "features": {
       "ranged": true,
       "bruiser": true,
-      "escape": true,
-      "offtank": true
+      "escape": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/dva/bust.jpg"
@@ -556,8 +553,7 @@
       "escape": true,
       "solo": true,
       "aa": true,
-      "percentage_dmg": true,
-      "offtank": true
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/leoric/bust.jpg"
@@ -849,8 +845,7 @@
       "finisher": true,
       "aa": true,
       "sustain_heal": true,
-      "cleanse": true,
-      "offtank": true
+      "cleanse": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/rehgar/bust.jpg"
@@ -919,8 +914,7 @@
       "initiation": true,
       "finisher": true,
       "solo": true,
-      "aa": true,
-      "offtank": true
+      "aa": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/sonya/bust.jpg"
@@ -1190,7 +1184,6 @@
       "finisher": true,
       "solo": true,
       "anti_shield": true,
-      "offtank": true,
       "anti_heal": true
     },
     "images": {
@@ -1247,8 +1240,7 @@
       "initiation": true,
       "aa": true,
       "cleanse": true,
-      "shield": true,
-      "offtank": true
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/zarya/bust.jpg"

--- a/public/heroes.json
+++ b/public/heroes.json
@@ -5,7 +5,8 @@
       "dd": true,
       "support": true,
       "global": true,
-      "pushing": true
+      "pushing": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/abathur/bust.jpg"
@@ -29,7 +30,8 @@
       "ranged": true,
       "support": true,
       "healer": true,
-      "escape": true
+      "escape": true,
+      "sustain_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/alexstrasza/bust.jpg"
@@ -41,7 +43,10 @@
       "ranged": true,
       "support": true,
       "healer": true,
-      "cc": true
+      "cc": true,
+      "sustain_heal": true,
+      "cleanse": true,
+      "anti_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/ana/bust.jpg"
@@ -56,7 +61,8 @@
       "cc": true,
       "summons": true,
       "escape": true,
-      "stun": true
+      "stun": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/anubarak/bust.jpg"
@@ -71,7 +77,8 @@
       "dd": true,
       "initiaton": true,
       "blind": true,
-      "solo": true
+      "solo": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/artanis/bust.jpg"
@@ -86,7 +93,8 @@
       "solo": true,
       "slow": true,
       "roots": true,
-      "selfsustain": true
+      "selfsustain": true,
+      "burst_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/arthas/bust.jpg"
@@ -99,7 +107,8 @@
       "healer": true,
       "support": true,
       "stun": true,
-      "blind": true
+      "blind": true,
+      "long_fights": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/auriel/bust.jpg"
@@ -148,7 +157,9 @@
       "support": true,
       "cc": true,
       "global": true,
-      "selfsustain": true
+      "selfsustain": true,
+      "sustain_heal": true,
+      "cleanse": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/brightwing/bust.jpg"
@@ -215,7 +226,8 @@
     "features": {
       "ranged": true,
       "bruiser": true,
-      "escape": true
+      "escape": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/dva/bust.jpg"
@@ -228,7 +240,9 @@
       "support": true,
       "roots": true,
       "slow": true,
-      "cc": true
+      "cc": true,
+      "sustain_heal": true,
+      "long_fights": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/deckard/bust.jpg"
@@ -304,7 +318,8 @@
       "waveclear": true,
       "finisher": true,
       "solo": true,
-      "selfsustain": true
+      "selfsustain": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/fenix/bust.jpg"
@@ -361,7 +376,9 @@
       "camping": true,
       "finisher": true,
       "waveclear": true,
-      "solo": true
+      "solo": true,
+      "percentage_dmg": true,
+      "burst": true
   },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/greymane/bust.jpg"
@@ -481,7 +498,8 @@
       "waveclear": true,
       "roots": true,
       "burst": true,
-      "cc": true
+      "cc": true,
+      "anti_shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/kelthuzad/bust.jpg"
@@ -517,7 +535,9 @@
       "finisher": true,
       "escape": true,
       "mobility": true,
-      "solo": true
+      "solo": true,
+      "cleanse": true,
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/kharazim/bust.jpg"
@@ -535,7 +555,9 @@
       "initiation": true,
       "escape": true,
       "solo": true,
-      "aa": true
+      "aa": true,
+      "percentage_dmg": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/leoric/bust.jpg"
@@ -549,7 +571,9 @@
       "healer": true,
       "slow": true,
       "stun": true,
-      "blind": true
+      "blind": true,
+      "sustain_heal": true,
+      "cleanse": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/li-li/bust.jpg"
@@ -576,7 +600,11 @@
       "ranged": true,
       "support": true,
       "healer": true,
-      "global": true
+      "global": true,
+      "burst_heal": true,
+      "long_fights": true,
+      "shield": true,
+      "anti_shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/lt-morales/bust.jpg"
@@ -607,7 +635,9 @@
       "healer": true,
       "finisher": true,
       "escape": true,
-      "mobility": true
+      "mobility": true,
+      "sustain_heal": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/lucio/bust.jpg"
@@ -637,7 +667,10 @@
       "healer": true,
       "slow": true,
       "roots": true,
-      "silence": true
+      "silence": true,
+      "sustain_heal": true,
+      "long_fights": true,
+      "cleanse": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/malfurion/bust.jpg"
@@ -655,7 +688,8 @@
       "selfsustain": true,
       "initiation": true,
       "finisher": true,
-      "mobility": true
+      "mobility": true,
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/malthael/bust.jpg"
@@ -672,7 +706,8 @@
       "silence": true,
       "initiation": true,
       "escape": true,
-      "mobility": true
+      "mobility": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/medivh/bust.jpg"
@@ -796,7 +831,8 @@
       "dd": true,
       "support": true,
       "selfsustain": true,
-      "stun": true
+      "stun": true,
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/raynor/bust.jpg"
@@ -811,7 +847,10 @@
       "slow": true,
       "waveclear": true,
       "finisher": true,
-      "aa": true
+      "aa": true,
+      "sustain_heal": true,
+      "cleanse": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/rehgar/bust.jpg"
@@ -880,7 +919,8 @@
       "initiation": true,
       "finisher": true,
       "solo": true,
-      "aa": true
+      "aa": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/sonya/bust.jpg"
@@ -914,7 +954,8 @@
       "cc": true,
       "silence": true,
       "roots": true,
-      "aa": true
+      "aa": true,
+      "burst_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/stukov/bust.jpg"
@@ -952,7 +993,8 @@
       "escape": true,
       "solo": true,
       "aa": true,
-      "scout": true
+      "scout": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/tassadar/bust.jpg"
@@ -1034,7 +1076,8 @@
       "dd": true,
       "waveclear": true,
       "burst": true,
-      "finisher": true
+      "finisher": true,
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/tychus/bust.jpg"
@@ -1052,7 +1095,8 @@
       "initiation": true,
       "escape": true,
       "solo": true,
-      "aa": true
+      "aa": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/tyrael/bust.jpg"
@@ -1068,7 +1112,8 @@
       "selfsustain": true,
       "stun": true,
       "scout": true,
-      "stealth": true
+      "stealth": true,
+      "cleanse": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/tyrande/bust.jpg"
@@ -1084,7 +1129,10 @@
       "healer": true,
       "selfsustain": true,
       "stun": true,
-      "solo": true
+      "solo": true,
+      "burst_heal": true,
+      "cleanse": true,
+      "shield": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/uther/bust.jpg"
@@ -1120,7 +1168,8 @@
       "finisher": true,
       "escape": true,
       "solo": true,
-      "aa": true
+      "aa": true,
+      "percentage_dmg": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/valla/bust.jpg"
@@ -1139,7 +1188,10 @@
       "selfsustain": true,
       "initiation": true,
       "finisher": true,
-      "solo": true
+      "solo": true,
+      "anti_shield": true,
+      "offtank": true,
+      "anti_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/varian/bust.jpg"
@@ -1157,7 +1209,8 @@
       "initiation": true,
       "solo": true,
       "summons": true,
-      "aa": true
+      "aa": true,
+      "anti_heal": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/xul/bust.jpg"
@@ -1192,7 +1245,10 @@
       "waveclear": true,
       "cc": true,
       "initiation": true,
-      "aa": true
+      "aa": true,
+      "cleanse": true,
+      "shield": true,
+      "offtank": true
     },
     "images": {
       "bust": "https://blzmedia-a.akamaihd.net/heroes/zarya/bust.jpg"

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,63 @@
 .app {
   background-color: #0d0119;
   color: #ccc;
+  min-height: 100vh;
 }
 
 .app__hero-table tbody {
   vertical-align: top;
+}
+
+.counter-pick {
+  padding: 10px;
+}
+
+.title {
+  font-weight: bold;
+}
+
+.counter-pick .case-item {
+  display: inline-block;
+  position: relative;
+  vertical-align: top;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 2px 5px;
+  margin: 2px 5px;
+  cursor: pointer;
+}
+
+.counter-pick .case-item .details {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  opacity: 0;
+  height: 0;
+  width: 0;
+}
+
+.counter-pick .case-item:hover .details {
+  display: block;
+  background: #ccc;
+  color: #444;
+  border-radius: 0 3px 3px 3px;
+  padding: 5px;
+  opacity: 1;
+  height: auto;
+  width: 200px;
+  transition: opacity 0.3s ease-out;
+}
+
+.counter-pick .case-item.selected {
+  background: green;
+}
+
+.empty-message {
+  display: inline-block;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 10vh;
+  font-size: 18px;
+  color: #eee;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,7 @@
   opacity: 0;
   height: 0;
   width: 0;
+  overflow: hidden;
 }
 
 .counter-pick-filter__case-item:hover .counter-pick-filter__case-item_details {

--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,7 @@
   vertical-align: top;
 }
 
-.counter-pick {
+.counter-pick-filter {
   padding: 10px;
 }
 
@@ -16,7 +16,7 @@
   font-weight: bold;
 }
 
-.counter-pick .case-item {
+.counter-pick-filter__case-item {
   display: inline-block;
   position: relative;
   vertical-align: top;
@@ -27,7 +27,7 @@
   cursor: pointer;
 }
 
-.counter-pick .case-item .details {
+.counter-pick-filter__case-item_details {
   position: absolute;
   top: 100%;
   left: 0;
@@ -36,7 +36,7 @@
   width: 0;
 }
 
-.counter-pick .case-item:hover .details {
+.counter-pick-filter__case-item:hover .counter-pick-filter__case-item_details {
   display: block;
   background: #ccc;
   color: #444;
@@ -48,7 +48,7 @@
   transition: opacity 0.3s ease-out;
 }
 
-.counter-pick .case-item.selected {
+.counter-pick-filter__case-item.selected {
   background: green;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,13 +4,20 @@ import './App.css';
 import Hero from './ui/Hero'
 import Feature from './entities/Feature'
 import FeatureFilter from './ui/FeatureFilter'
+import CounterPickFilter from './ui/CounterPickFilter';
 import arrayToTable from './util/arrayToTable'
 import sortBy from './util/sortBy'
 import mapToObjects from './util/mapToObjects'
+const mergeObjects = (a, b) => Object.assign({}, a, b)
 
 class App extends Component {
   state = {
-    filterSelection: {}
+    filterSelection: {},
+    filterCounterPickSelection: {},
+    features: [],
+    heroes: [],
+    counterPicks: [],
+    moreThen2FilterMode: false
   }
 
   componentDidMount() {
@@ -18,21 +25,43 @@ class App extends Component {
          .then(response => this.setState({ features: sortBy(mapToObjects(response.data, Feature), 'title') }));
     axios.get('/heroes.json')
          .then(response => this.setState({ heroes: sortBy(response.data, 'name') }));
+    axios.get('/counter-pick.json')
+         .then(response => this.setState({ counterPicks: sortBy(response.data, 'title') }));
+  }
+
+  updateFilters = (c) => {
+    this.setState({ 
+      filterSelection: mergeObjects(this.state.filterSelection, c)
+    })
+  }
+
+  setCounterFilters = (filterCounterPickSelection) => {
+    this.setState({
+      // filterSelection: {},
+      filterCounterPickSelection,
+      moreThen2FilterMode: Object.keys(filterCounterPickSelection).length > 0
+    });
   }
 
   render() {
-    const {filterSelection, features} = this.state;
-    const mergeObjects = (a, b) => Object.assign({}, a, b)
-
+    const {filterSelection, features, counterPicks} = this.state;
+    const rows = this.rowsOfHeroes();
     return (
       <div className="app">
+        <div className="title">
+          What do we need to counter:
+        </div>
+        <CounterPickFilter cases={counterPicks} onChange={this.setCounterFilters} />
+        <div className="title">
+          Additional filters:
+        </div>
         <FeatureFilter features={features || []}
                        selection={{}}
-                       onChange={c => this.setState({ filterSelection: mergeObjects(filterSelection, c) })} />
+                       onChange={this.updateFilters} />
         <table className='app__hero-table'>
           <tbody>
             {
-              this.rowsOfHeroes().map(
+              rows.map(
                 (row, i) => <tr key={i}>
                               {row.map(h => <td key={h.name}><Hero data={h} /></td>)}
                             </tr>
@@ -40,6 +69,7 @@ class App extends Component {
             }
           </tbody>
         </table>
+        {rows.length == 0 && (<div className="empty-message">There is no such hero. Try to make filter strict less.</div>)}
       </div>
     );
   }
@@ -52,22 +82,32 @@ class App extends Component {
   }
 
   filteredHeroes() {
-    const {filterSelection} = this.state;
+    const { filterSelection, filterCounterPickSelection, moreThen2FilterMode } = this.state;
     const heroes = this.state.heroes || [];
     if(!this.isFilterEnabled()) {
       return heroes;
     }
-
+ 
     const requiredFeatures = Object.entries(filterSelection)
                                    .filter(keyvalue => keyvalue[1])
                                    .map(keyvalue => keyvalue[0]);
+    const requiredCounterPickFeatures = Object.entries(filterCounterPickSelection)
+                                   .filter(keyvalue => keyvalue[1])
+                                   .map(keyvalue => keyvalue[0]);                                   
+    const heroFilter = h =>  {
+     
+      if (!moreThen2FilterMode) {
+        return !requiredFeatures.find(f => !h.features[f]);
+      }
 
-    const heroFilter = h => !requiredFeatures.find(f => !h.features[f]);
+      const rfH = requiredCounterPickFeatures.filter(f => h.features[f]);
+      return rfH.length >= 3 && (requiredFeatures.length == 0 || !requiredFeatures.find(f => !h.features[f]));
+    }
     return heroes.filter(heroFilter);
   }
 
   isFilterEnabled() {
-    return -1 !== Object.values(this.state.filterSelection).indexOf(true);
+    return -1 !== Object.values(this.state.filterSelection).indexOf(true) || -1 !== Object.values(this.state.filterCounterPickSelection).indexOf(true);
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -29,13 +29,13 @@ class App extends Component {
          .then(response => this.setState({ counterPicks: sortBy(response.data, 'title') }));
   }
 
-  updateFilters = (c) => {
+  updateFilters (c) {
     this.setState({ 
       filterSelection: mergeObjects(this.state.filterSelection, c)
     })
   }
 
-  setCounterFilters = (filterCounterPickSelection) => {
+  setCounterFilters(filterCounterPickSelection) {
     this.setState({
       // filterSelection: {},
       filterCounterPickSelection,
@@ -44,20 +44,20 @@ class App extends Component {
   }
 
   render() {
-    const {filterSelection, features, counterPicks} = this.state;
+    const {features, counterPicks} = this.state;
     const rows = this.rowsOfHeroes();
     return (
       <div className="app">
         <div className="title">
           What do we need to counter:
         </div>
-        <CounterPickFilter cases={counterPicks} onChange={this.setCounterFilters} />
+        <CounterPickFilter cases={counterPicks} onChange={this.setCounterFilters.bind(this)} />
         <div className="title">
           Additional filters:
         </div>
         <FeatureFilter features={features || []}
                        selection={{}}
-                       onChange={this.updateFilters} />
+                       onChange={this.updateFilters.bind(this)} />
         <table className='app__hero-table'>
           <tbody>
             {
@@ -69,7 +69,7 @@ class App extends Component {
             }
           </tbody>
         </table>
-        {rows.length == 0 && (<div className="empty-message">There is no such hero. Try to make filter strict less.</div>)}
+        {rows.length === 0 && (<div className="empty-message">There is no such hero. Try to make filter strict less.</div>)}
       </div>
     );
   }
@@ -101,7 +101,7 @@ class App extends Component {
       }
 
       const rfH = requiredCounterPickFeatures.filter(f => h.features[f]);
-      return rfH.length >= 3 && (requiredFeatures.length == 0 || !requiredFeatures.find(f => !h.features[f]));
+      return rfH.length >= 3 && (requiredFeatures.length === 0 || !requiredFeatures.find(f => !h.features[f]));
     }
     return heroes.filter(heroFilter);
   }

--- a/src/data.test.js
+++ b/src/data.test.js
@@ -1,5 +1,6 @@
 import heroes from '../public/heroes.json';
 import features from '../public/features.json';
+import counterPicks from '../public/counter-pick.json';
 
 it('imports successfuly', () => {
   // build won't be successful if json cant be parsed

--- a/src/ui/CounterPickFilter.js
+++ b/src/ui/CounterPickFilter.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types'; // ES6
+import { list } from 'postcss';
+
+const CaseItem = ({ id, title, description = '', onClick = () => {}, features = [], selected = false }) => (
+  <div className={`case-item ${selected? 'selected': ''}`} onClick={onClick} >
+    <div className="title" title={description} >
+      {title||id}
+    </div>
+
+    <div className="details">
+      {description}
+      <hr/>
+      Requires at least 3 of this:
+      <ul>
+        {features.map( (f, index) => <li key={index}>{f} </li>)}
+      </ul>
+    </div>
+     
+  </div>
+);
+
+class CounterPickFilter extends React.Component {
+
+  state = {
+    selectedItem: null,
+  }
+
+  selectItem = (selectedItem) => {
+    if (this.state.selectedItem === selectedItem) { // deselect
+      return this.disableFilter();
+    }
+    this.setState({
+      selectedItem
+    });
+    const filtersMap = {};
+    selectedItem.features.forEach(feature => {
+      filtersMap[feature] = true;
+    });
+    this.props.onChange(filtersMap);
+  }
+
+  disableFilter = () => {
+    this.setState({
+      selectedItem: null
+    });
+    this.props.onChange({});
+  }
+
+  render() {
+    return(
+      <div className="counter-pick">
+        {
+          this.props.cases.map(item => <CaseItem key={item.id} {...item} selected={item === this.state.selectedItem} onClick={() => this.selectItem(item)} />)
+        }
+      </div>
+    );
+  }
+}
+
+CounterPickFilter.propTypes = {
+  cases: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      features: PropTypes.arrayOf(PropTypes.string).isRequired,
+      title: PropTypes.string,
+      description: PropTypes.string
+    })
+  ),
+  onChange: PropTypes.func.isRequired
+};
+
+export default CounterPickFilter;

--- a/src/ui/CounterPickFilter.js
+++ b/src/ui/CounterPickFilter.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types'; // ES6
-import { list } from 'postcss';
 
 const CaseItem = ({ id, title, description = '', onClick = () => {}, features = [], selected = false }) => (
-  <div className={`case-item ${selected? 'selected': ''}`} onClick={onClick} >
+  <div className={`counter-pick-filter__case-item ${selected? 'selected': ''}`} onClick={onClick} >
     <div className="title" title={description} >
       {title||id}
     </div>
 
-    <div className="details">
+    <div className="counter-pick-filter__case-item_details">
       {description}
       <hr/>
       Requires at least 3 of this:
@@ -49,7 +48,7 @@ class CounterPickFilter extends React.Component {
 
   render() {
     return(
-      <div className="counter-pick">
+      <div className="counter-pick-filter">
         {
           this.props.cases.map(item => <CaseItem key={item.id} {...item} selected={item === this.state.selectedItem} onClick={() => this.selectItem(item)} />)
         }

--- a/src/ui/CounterPickFilter.js
+++ b/src/ui/CounterPickFilter.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types'; // ES6
 
-const CaseItem = ({ id, title, description = '', onClick = () => {}, features = [], selected = false }) => (
+const CaseItem = ({ id, title, description = '', onClick = () => {}, features = {}, selected = false }) => (
   <div className={`counter-pick-filter__case-item ${selected? 'selected': ''}`} onClick={onClick} >
     <div className="title" title={description} >
       {title||id}
@@ -12,7 +12,7 @@ const CaseItem = ({ id, title, description = '', onClick = () => {}, features = 
       <hr/>
       Requires at least 3 of this:
       <ul>
-        {features.map( (f, index) => <li key={index}>{f} </li>)}
+        {Object.keys(features).map( (f, index) => <li key={index}>{f} </li>)}
       </ul>
     </div>
      
@@ -33,7 +33,7 @@ class CounterPickFilter extends React.Component {
       selectedItem
     });
     const filtersMap = {};
-    selectedItem.features.forEach(feature => {
+    Object.keys(selectedItem.features).forEach(feature => {
       filtersMap[feature] = true;
     });
     this.props.onChange(filtersMap);
@@ -61,7 +61,7 @@ CounterPickFilter.propTypes = {
   cases: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      features: PropTypes.arrayOf(PropTypes.string).isRequired,
+      features: PropTypes.objectOf(PropTypes.bool).isRequired,
       title: PropTypes.string,
       description: PropTypes.string
     })


### PR DESCRIPTION
Added a "CounterPick filter" - now you can choose what team-composition you want to counter - it will show you a set of heroes. Then you can specify it with a regular filters. You can still use regular filters without counter-pick filter, like you did it before, or use it together.
Description about each filter-item provided by cursor-hover.

All the items for the new filter are available in `counter-pick.json`, it's configurable.

Now the App looks like this:

![image](https://user-images.githubusercontent.com/1695498/40629931-99dc5cda-62ce-11e8-86be-ea85d5cc0d80.png)
